### PR TITLE
Add permissive option allowing for arbitrary Solr parameter

### DIFF
--- a/conf/ds-discover-behaviour.yaml
+++ b/conf/ds-discover-behaviour.yaml
@@ -14,6 +14,12 @@ config:
     max: 10000
 
   solr:
+    # If permissive is false, only vetted Solr parameters are accepted
+    # If permissive is true, all Solr parameters are passed on and non-vetted parameters are logged
+    # Intended for development purposes.
+    # WARNING: This should never be true in production.
+    permissive: false
+
     # Test purpose only in ds-discover-behaviour.yaml. Override in environment configuration.
     collections:
       # Keys are collection names

--- a/src/main/java/dk/kb/discover/SolrService.java
+++ b/src/main/java/dk/kb/discover/SolrService.java
@@ -28,6 +28,7 @@ import java.net.http.HttpResponse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -160,10 +161,11 @@ public class SolrService {
      * @see <a href="https://solr.apache.org/guide/solr/latest/query-guide/morelikethis.html">Solr MLT</a>.
      * @return solr More Like This response.
      */
+    @SuppressWarnings("SuspiciousTernaryOperatorInVarargsCall")
     public String mlt(String q, List<String> fq, Integer rows, Integer start, String fl, String qOp, String wt,
                       String mltFl, Integer mltMintf, Integer mltMindf, Integer mltMaxdf, Integer mltMaxdfpct,
                       Integer mltMinwl, Integer mltMaxwl, Integer mltMaxqt, Boolean mltBoost,
-                      String mltInterestingTerms) {
+                      String mltInterestingTerms, Map<String, String[]> extra) {
         if (q == null) {
             throw new InvalidArgumentServiceException("q is mandatory but was missing");
         }
@@ -181,6 +183,11 @@ public class SolrService {
         addParamIfAvailable(builder, MLT_BOOST, mltBoost);
         if (mltInterestingTerms != null) {
             builder.queryParam(MLT_INTERESTING_TERMS, MLT_INTERESTING_TERMS_ENUM.safeParse(mltInterestingTerms));
+        }
+        if (extra != null) {
+            extra.forEach((key, values) ->
+                    Arrays.stream(values).forEach(
+                            value -> builder.queryParam(key, value)));
         }
 
         return performCall(q, builder, "mlt");
@@ -200,9 +207,11 @@ public class SolrService {
      * @param indent                 if true, Solr response is indented (if possible).
      * @param debug                  as enumerated in {@link DEBUG_ENUM}.
      * @param debugExplainStructured true if debug information should be structuredinstead of just a string.
+     * @param extra                  optional extra parameters.
      * @return Solr response.
      */
-    public String query(String q, List<String> fq, Integer rows, Integer start, String fl, String facet, List<String> facetField, String qOp, String wt, String version, String indent, String debug, String debugExplainStructured) {
+    @SuppressWarnings("SuspiciousTernaryOperatorInVarargsCall")
+    public String query(String q, List<String> fq, Integer rows, Integer start, String fl, String facet, List<String> facetField, String qOp, String wt, String version, String indent, String debug, String debugExplainStructured, Map<String, String[]> extra) {
         if (q == null) {
             throw new InvalidArgumentServiceException("q is mandatory but was missing");
         }
@@ -223,6 +232,12 @@ public class SolrService {
         }
         if (debugExplainStructured != null || debug != null) {
             builder.queryParam(DEBUG_EXPLAIN_STRUCTURED, Boolean.parseBoolean(debugExplainStructured));
+        }
+
+        if (extra != null) {
+            extra.forEach((key, values) ->
+                    Arrays.stream(values).forEach(
+                            value -> builder.queryParam(key, value)));
         }
 
         return performCall(q, builder, "search");

--- a/src/main/java/dk/kb/discover/api/v1/impl/DsDiscoverApiServiceImpl.java
+++ b/src/main/java/dk/kb/discover/api/v1/impl/DsDiscoverApiServiceImpl.java
@@ -251,7 +251,7 @@ public class DsDiscoverApiServiceImpl extends ImplBase implements DsDiscoverApi 
     }
 
     /**
-     * Timy helper for creating a proper toString for maps with String arrays as values.
+     * Tiny helper for creating a proper toString for maps with String arrays as values.
      * @param map a {@code String -> String[]} map.
      * @return human readable representation of {@code map}.
      */

--- a/src/test/java/dk/kb/discover/SolrServiceTest.java
+++ b/src/test/java/dk/kb/discover/SolrServiceTest.java
@@ -23,7 +23,7 @@ class SolrServiceTest {
     //@Test
     void baseSearch() {
         SolrService solr = new SolrService("test", "http://localhost:10007", "solr", "ds");
-        String response = solr.query("*:*", null, null, null, null, null, null, null, null, null, null, null, null);
+        String response = solr.query("*:*", null, null, null, null, null, null, null, null, null, null, null, null, null);
         assertTrue(response.contains("responseHeader"), "The Solr response should contain a header");
     }
 }


### PR DESCRIPTION
If the Solr config is set to permissive, all parameters are passed through to Solr. If it is not permissive, issuing a Solr call with any non-vetted parameters will result in an exception.

The default is false and this should only be enabled on local or devel for decoupling ad hoc frontend tweaking of Solr calls from enabling of said tweaks in ds-discover. The non-vetted arguments are logged on `warn` for later incorporation in ds-discover.