### PR TITLE
Remove internal filter queries (fq) from Solr response

### DIFF
--- a/src/main/java/dk/kb/discover/SolrService.java
+++ b/src/main/java/dk/kb/discover/SolrService.java
@@ -354,9 +354,9 @@ public class SolrService {
      * Remove filters with {@code prefix} from the {@code params.fq} entries in {@code solrResponse}.
      * Intended use is to remove internal licensing information from responses returned to external caller.
      * <p>
-     * Note: This uses regexp-based search/replace to adjust JSON & XML. This is error prone and should generally be
-     *       avoided. It is used here
-     *
+     * Note: This uses regexp-based search/replace to adjust JSON & XML.
+     *       This is error prone and should generally be avoided.
+     *       It is used here as the service is expected to under heavy load so performance is a high priority.
      * @param solrResponse a Solr search response in {@code wt} format.
      * @param prefix the prefix identifying the filter to remove, e.g. {@code {!cache=true}}.
      * @param wt the delivery format ({@code json}, {@code xml}, {@code csv}). null means {@code json}.

--- a/src/main/java/dk/kb/discover/SolrService.java
+++ b/src/main/java/dk/kb/discover/SolrService.java
@@ -392,6 +392,8 @@ public class SolrService {
      */
     // TODO: This uses 3 regexp-based search-replace, which will be heavy on large inputs. Consider CallbackReplacer
     private static String removePrefixedFiltersJSON(String solrResponse, String prefix) {
+        // In the sample below, the filter starting with {!cache=true} is to be removed
+
 //     "fq": [
 //        "number_of_episodes:[2 TO 10]",
 //        "resource_description:[* TO \"Moving Image\"]",
@@ -430,11 +432,13 @@ public class SolrService {
      * @throws IllegalArgumentException if the {@code solrResponse} did not contain a prefixed filter.
      */
     private static String removePrefixedFilterXML(String solrResponse, String prefix) {
-        //    <str name="q.op">AND</str>
+        // In the sample below, the filter starting with {!cache=true} is to be removed
+
+//    <str name="q.op">AND</str>
 //    <arr name="fq">
 //      <str>number_of_episodes:[2 TO 10]</str>
 //      <str>resource_description:[* TO "Moving Image"]</str>
-//      <str>(((access_searlige_visningsvilkaar:"Visning kun af metadata") OR (catalog:"Maps") OR (collection:"Det Kgl. Bibliotek; Radio/TV-Samlingen") OR (catalog:"Samlingsbilleder")) -(id:("fr508045.tif" OR "fr552041x.tif")) -(access_blokeret:true) -(cataloging_language:*tysk*))</str>
+//      <str>{!cache=true}(((access_searlige_visningsvilkaar:"Visning kun af metadata") OR (catalog:"Maps") OR (collection:"Det Kgl. Bibliotek; Radio/TV-Samlingen") OR (catalog:"Samlingsbilleder")) -(id:("fr508045.tif" OR "fr552041x.tif")) -(access_blokeret:true) -(cataloging_language:*tysk*))</str>
 //    </arr>
         Pattern stripPattern = Pattern.compile(
                 " *<str>" + Pattern.quote(prefix) + ".*?</str>\n?", Pattern.DOTALL);

--- a/src/test/java/dk/kb/discover/SolrServiceTest.java
+++ b/src/test/java/dk/kb/discover/SolrServiceTest.java
@@ -90,7 +90,7 @@ class SolrServiceTest {
                 "      <str>resource_description:[* TO \"Moving Image\"]</str>\n" +
                 "      <str>{!cache=true}(((access_searlige_visningsvilkaar:\"Visning kun af metadata\") OR (catalog:\"Maps\") OR (collection:\"Det Kgl. Bibliotek; Radio/TV-Samlingen\") OR (catalog:\"Samlingsbilleder\")) -(id:(\"fr508045.tif\" OR \"fr552041x.tif\")) -(access_blokeret:true) -(cataloging_language:*tysk*))</str>\n" +
                 "    </arr>\n";
-        String exp = "<str name=\"q.op\">AND</str>\n" +
+        String exp = "  <str name=\"q.op\">AND</str>\n" +
                 "    <arr name=\"fq\">\n" +
                 "      <str>number_of_episodes:[2 TO 10]</str>\n" +
                 "      <str>resource_description:[* TO \"Moving Image\"]</str>\n" +


### PR DESCRIPTION
Access filtering is handled by adding filter queries from ds-license to the request to Solr. The access filter is part of the Solr response when using json or xml response format. This is internal information: Not relevant for the caller and potentially sensitive information.

This pull request removes such filters. It uses search/replace, which is error prone but fast, compared to fully parsing the Solr result, removing the relevant element and serializing to String for final delivery.