### PR TITLE
Fix double encoding problem

### DIFF
--- a/src/main/java/dk/kb/discover/SolrService.java
+++ b/src/main/java/dk/kb/discover/SolrService.java
@@ -65,7 +65,7 @@ public class SolrService {
     public static final String SPELLCHECK_DICTIONARY = "spellcheck.dictionary";
     public static final String SPELLCHECK_COUNT= "spellcheck.count";
     public static final String SPELLCHECK_ONLY_MORE_POPULAR= "spellcheck.onlyMorePopular";
-    public static final String SPELLCHECK_EXTENDED_RESULTS= "spellcheck.extendedResults ";
+    public static final String SPELLCHECK_EXTENDED_RESULTS= "spellcheck.extendedResults";
     public static final String SPELLCHECK_COLLATE= "spellcheck.collate";
     public static final String SPELLCHECK_MAX_COLLATIONS= "spellcheck.maxCollations";       
     public static final String SPELLCHECK_MAX_COLLATION_TRIES= "spellcheck.maxCollationTries";


### PR DESCRIPTION
When adding a query param using the UriBuilder where the key contains a space, e.g.
  builder.queryParam("key space", "some value")
ALL query param VALUES will be double encoded when builder.build() is called. The key with the value will be properly encoded (with %20 instead of space). Looks like an error in the UriBuilder.

This pull request fixes the concrete problem, where a key contained a space due to a typo.
Thanks to @VictorHarbo for participating in Pair Debugging.