### PR TITLE
Disc 748 spellcheck api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added git information to the status endpoint. It now delivers, deployed branch name, commit hash, time of latest commit and closest tag
+- Added spellcheck parameters to /select method method when querying Solr
 
 ## [1.2.0](https://github.com/kb-dk/ds-discover/releases/tag/ds-discover-1.2.0) - 2024-01-22
 ### Added

--- a/src/main/java/dk/kb/discover/SolrService.java
+++ b/src/main/java/dk/kb/discover/SolrService.java
@@ -314,22 +314,7 @@ public class SolrService {
         if (facetField != null) {
             facetField.forEach(ff -> builder.queryParam(FACET_FIELD, ff));
         }
-        
-        /*
-        //All the spellcheck parameters
-        if (spellcheck != null) {
-        	   builder.queryParam(SPELLCHECK, Boolean.parseBoolean(spellcheck));
-        }
-        
-        if (spellcheckBuild != null) {
-        	   builder.queryParam(SPELLCHECK_BUILD, Boolean.parseBoolean(spellcheckBuild));
-        }
-        
-        if (spellcheckReload != null) {
-     	   builder.queryParam(SPELLCHECK_RELOAD, Boolean.parseBoolean(spellcheckReload));
-        }
-        */
-        
+                      
         addParamIfAvailable(builder, SPELLCHECK, Boolean.parseBoolean(spellcheck));
         addParamIfAvailable(builder, SPELLCHECK_BUILD, Boolean.parseBoolean(spellcheckBuild));
         addParamIfAvailable(builder, SPELLCHECK_RELOAD, Boolean.parseBoolean(spellcheckReload));        

--- a/src/main/java/dk/kb/discover/SolrService.java
+++ b/src/main/java/dk/kb/discover/SolrService.java
@@ -57,7 +57,7 @@ public class SolrService {
     public static final String ROWS = "rows";
     public static final String START = "start";
     public static final String FACET = "facet";
-    public static final String FACET_FIELD = "facet.field";    
+    public static final String FACET_FIELD = "facet.field";
     public static final String SPELLCHECK = "spellcheck";
     public static final String SPELLCHECK_BUILD = "spellcheck.build";
     public static final String SPELLCHECK_RELOAD = "spellcheck.reload";

--- a/src/main/java/dk/kb/discover/SolrService.java
+++ b/src/main/java/dk/kb/discover/SolrService.java
@@ -543,15 +543,31 @@ public class SolrService {
     }
 
     /**
-     * If {@code value} is not null, {@code key=value} is added as a param to the builder.
+     * If {@code value} is not null, {@code key=value} is added as a param to the builder.<br>
+     * Also if String is empty or array is empty param will also not be added.  <br>
+     * Solr will fail on the query etc.: &spellcheck.dictionary=<br>
+     * This happens because openApi will set empty textboxes as 'parameter1='<br>
+     * The solr admin page does submit empty fields to parameter list<br>
+     * 
      * @param builder builder for a Solr query.
      * @param key     key for the param to add if a value is present.
      * @param value   value for the key.
      */
-    private void addParamIfAvailable(UriBuilder builder, String key, Object value) {
-        if (value != null) {
-            builder.queryParam(key, value);
-        }
+    private void addParamIfAvailable(UriBuilder builder, String key, Object value) {           
+    	if (value == null) {
+    		return;    		
+    	}
+    	else if (value instanceof String) {
+    		if ("".equals(value.toString().trim()));
+    	    return;
+    	}
+    	else if (value instanceof Object[]) {
+    		Object[] array = (Object[]) value;
+    		if (array.length == 0) {
+    			return;
+    		}
+    	}
+    	builder.queryParam(key, value); // There is some real value here.    	    	
     }
 
     /**

--- a/src/main/java/dk/kb/discover/SolrService.java
+++ b/src/main/java/dk/kb/discover/SolrService.java
@@ -57,7 +57,20 @@ public class SolrService {
     public static final String ROWS = "rows";
     public static final String START = "start";
     public static final String FACET = "facet";
-    public static final String FACET_FIELD = "facet.field";
+    public static final String FACET_FIELD = "facet.field";    
+    public static final String SPELLCHECK = "spellcheck";
+    public static final String SPELLCHECK_BUILD = "spellcheck.build";
+    public static final String SPELLCHECK_RELOAD = "spellcheck.reload";
+    public static final String SPELLCHECK_QUERY = "spellcheck.q";
+    public static final String SPELLCHECK_DICTIONARY = "spellcheck.dictionary";
+    public static final String SPELLCHECK_COUNT= "spellcheck.count";
+    public static final String SPELLCHECK_ONLY_MORE_POPULAR= "spellcheck.onlyMorePopular";
+    public static final String SPELLCHECK_EXTENDED_RESULTS= "spellcheck.extendedResults ";
+    public static final String SPELLCHECK_COLLATE= "spellcheck.collate";
+    public static final String SPELLCHECK_MAX_COLLATIONS= "spellcheck.maxCollations";       
+    public static final String SPELLCHECK_MAX_COLLATION_TRIES= "spellcheck.maxCollationTries";
+    public static final String SPELLCHECK_ACCURACY= "spellcheck.accuracy";
+        
     public static final String QOP = "q.op";
     public static final String WT = "wt";
     public static final String VERSION = "version"; // Used with wt=xml, always 2.2, not mandatory
@@ -250,6 +263,8 @@ public class SolrService {
 
     }
 
+   
+    
     /**
      * Issue a Solr query and return the result.
      *
@@ -267,7 +282,26 @@ public class SolrService {
      * @return Solr response.
      */
     @SuppressWarnings("SuspiciousTernaryOperatorInVarargsCall")
-    public String query(String q, List<String> fq, Integer rows, Integer start, String fl, String facet, List<String> facetField, String qOp, String wt, String version, String indent, String debug, String debugExplainStructured, Map<String, String[]> extra) {
+    public String query(String q,
+    		List<String> fq,
+    		Integer rows,
+    		Integer start,
+    		String fl,
+    		String facet,
+    		List<String> facetField,
+    		String spellcheck,
+    		String spellcheckBuild,
+    		String spellcheckReload,
+    		String spellcheckQuery,
+    		String spellcheckDictionary,    		                 
+            Integer spellcheckCount,
+    	    String spellchecKOnlyMorePopular,
+    	    String spellcheckExtendedResults,
+    	    String spellcheckCollate,
+    	    Integer spellcheckMaxCollations,
+    	    Integer spellcheckMaxCollationTries,
+    	    Double spellcheckAccuracy,
+    	    String qOp, String wt, String version, String indent, String debug, String debugExplainStructured, Map<String, String[]> extra) {
         if (q == null) {
             throw new InvalidArgumentServiceException("q is mandatory but was missing");
         }
@@ -280,6 +314,35 @@ public class SolrService {
         if (facetField != null) {
             facetField.forEach(ff -> builder.queryParam(FACET_FIELD, ff));
         }
+        
+        /*
+        //All the spellcheck parameters
+        if (spellcheck != null) {
+        	   builder.queryParam(SPELLCHECK, Boolean.parseBoolean(spellcheck));
+        }
+        
+        if (spellcheckBuild != null) {
+        	   builder.queryParam(SPELLCHECK_BUILD, Boolean.parseBoolean(spellcheckBuild));
+        }
+        
+        if (spellcheckReload != null) {
+     	   builder.queryParam(SPELLCHECK_RELOAD, Boolean.parseBoolean(spellcheckReload));
+        }
+        */
+        
+        addParamIfAvailable(builder, SPELLCHECK, Boolean.parseBoolean(spellcheck));
+        addParamIfAvailable(builder, SPELLCHECK_BUILD, Boolean.parseBoolean(spellcheckBuild));
+        addParamIfAvailable(builder, SPELLCHECK_RELOAD, Boolean.parseBoolean(spellcheckReload));        
+        addParamIfAvailable(builder, SPELLCHECK_QUERY, spellcheckQuery);
+        addParamIfAvailable(builder, SPELLCHECK_DICTIONARY, spellcheckDictionary);
+        addParamIfAvailable(builder, SPELLCHECK_COUNT, spellcheckCount);
+        addParamIfAvailable(builder, SPELLCHECK_ONLY_MORE_POPULAR, spellchecKOnlyMorePopular);
+        addParamIfAvailable(builder, SPELLCHECK_EXTENDED_RESULTS, spellcheckExtendedResults);               
+        addParamIfAvailable(builder, SPELLCHECK_COLLATE, spellcheckCollate);
+        addParamIfAvailable(builder, SPELLCHECK_MAX_COLLATIONS, spellcheckMaxCollations);
+        addParamIfAvailable(builder, SPELLCHECK_MAX_COLLATION_TRIES, spellcheckMaxCollationTries);
+        addParamIfAvailable(builder, SPELLCHECK_ACCURACY, spellcheckAccuracy);
+        
         addParamIfAvailable(builder, VERSION, version);
         addParamIfAvailable(builder, INDENT, indent);
 

--- a/src/main/java/dk/kb/discover/api/v1/impl/DsDiscoverApiServiceImpl.java
+++ b/src/main/java/dk/kb/discover/api/v1/impl/DsDiscoverApiServiceImpl.java
@@ -220,7 +220,34 @@ public class DsDiscoverApiServiceImpl extends ImplBase implements DsDiscoverApi 
       * @implNote return will always produce a HTTP 200 code. Throw ServiceException if you need to return other codes
      */
     @Override
-    public String solrSearch(String collection, String q, List<String> fq, Integer rows, Integer start, String fl, String facet, List<String> facetField, String qOp, String wt, String version, String indent, String debug, String debugExplainStructured) {
+    public String solrSearch(String collection,
+    		                 String q, 
+    		                 List<String> fq,
+    		                 Integer rows,
+    		                 Integer start,
+    		                 String fl,
+    		                 String facet,
+    		                 List<String> facetField,
+    		                 String spellcheck,
+    		                 String spellcheckBuild,
+    		                 String spellcheckReload,
+    		                 String spellcheckQuery,
+    		                 String spellcheckDictionary,    		                 
+    		                 Integer spellcheckCount,
+    		                 String spellchecKOnlyMorePopular,
+    		                 String spellcheckExtendedResults,
+    		                 String spellcheckCollate,
+    		                 Integer spellcheckMaxCollations,
+    		                 Integer spellcheckMaxCollationTries,
+    		                 Double spellcheckAccuracy,
+    		                 String qOp,
+    		                 String wt,
+    		                 String version,
+    		                 String indent,
+    		                 String debug,
+    		                 String debugExplainStructured) {
+    
+    	
     
         try {
 
@@ -242,7 +269,9 @@ public class DsDiscoverApiServiceImpl extends ImplBase implements DsDiscoverApi 
             //Add filter query from license module.
             fq = addAccessFilter("solrSearch", fq);
 
-            String rawResponse = solr.query(q, fq, rows, start, fl, facet, facetField, qOp,
+            String rawResponse = solr.query(q, fq, rows, start, fl, facet, facetField,
+            		spellcheck,spellcheckBuild,spellcheckReload,spellcheckQuery,spellcheckDictionary,spellcheckCount,spellchecKOnlyMorePopular,spellcheckExtendedResults,spellcheckCollate,spellcheckMaxCollations,spellcheckMaxCollationTries,spellcheckAccuracy,
+            		qOp,
                     wt, version, indent, debug, debugExplainStructured, extra);
             return SolrService.removePrefixedFilters(rawResponse, FILTER_CACHE_PREFIX, wt);
         } catch (Exception e){

--- a/src/main/openapi/ds-discover-openapi_v1.yaml
+++ b/src/main/openapi/ds-discover-openapi_v1.yaml
@@ -235,6 +235,144 @@ paths:
 
         # TODO: Add more facet variables
 
+
+
+        # Spell check fields
+        - name: spellcheck
+          in: query
+          description: | 
+            Solr spellcheck enabling [spellcheck](https://solr.apache.org/guide/solr/latest/query-guide/spell-checking.html)
+            
+            If true, solr response will contain spellcheck information. Spellcheck will only be activated by Solr if no results are found
+          required: false
+          schema:
+            type: string
+            enum: ['true', 'false']
+            default: 'false'
+            example: 'false'
+       
+        - name: spellcheck.build
+          in: query
+          description: | 
+            Setting to true will rebuild the spellcheck index. The dictionary will take some time to build, so this parameter should not be sent with every request.
+                        
+          required: false
+          schema:
+            type: string
+            enum: ['true', 'false']
+            default: 'false'
+            example: 'false'
+
+        - name:  spellcheck.reload 
+          in: query
+          description: | 
+            Setting to true will reload the spellcheck index. 
+                        
+          required: false
+          schema:
+            type: string
+            enum: ['true', 'false']
+            default: 'false'
+            example: 'false'
+
+        - name: spellcheck.q
+          in: query
+          description: 'Same as the query field, but use this value for spellcheck instead. If empty it will use the query parameter'
+          required: false
+          schema:
+            type: string
+            default: ''
+
+        - name: spellcheck.dictionary
+          in: query
+          description: 'Specific another spellcheck dictionary to use if several are defined'
+          required: false
+          schema:
+            type: string
+            default: ''
+
+        - name: spellcheck.count
+          in: query
+          description: | 
+            Maximum suggestion from the spellcheck compontent                      
+          required: false
+          schema:
+            type: integer
+            format: int32
+            example: 5
+            default: 5
+        
+        - name: spellcheck.onlyMorePopular 
+          in: query
+          description: | 
+            If true, Solr will to return suggestions that result in more hits for the query than the existing query 
+                        
+          required: false
+          schema:
+            type: string
+            enum: ['true', 'false']
+            default: 'false'
+            example: 'false'
+        
+        - name: spellcheck.extendedResults 
+          in: query
+          description: |
+            Causes Solr to return additional information about spellcheck results, such as the frequency of each original term in the index (origFreq) as well as the frequency of each suggestion in the index (frequency).
+                        
+          required: false
+          schema:
+            type: string
+            enum: ['true', 'false']
+            default: 'false'
+            example: 'false'
+        
+        - name: spellcheck.collate 
+          in: query
+          description: |          
+            If true, this parameter directs Solr to take the best suggestion for each token (if one exists) and construct a new query from the suggestions.
+                        
+          required: false
+          schema:
+            type: string
+            enum: ['true', 'false']
+            default: 'false'
+            example: 'false'
+
+        - name: spellcheck.maxCollations 
+          in: query
+          description: |
+            This parameter specifies the maximum number of collations to return.
+                        
+          required: false
+          schema:
+            type: integer
+            format: int32
+            example: 10
+            default: 10
+        - name: spellcheck.maxCollationTries
+          in: query
+          description: |
+            This parameter specifies the number of collation possibilities for Solr to try before giving up.
+                        
+          required: false
+          schema:
+            type: integer
+            format: int32
+            example: 10
+            default: 10
+
+        - name: spellcheck.accuracy 
+          in: query
+          description: |
+           Specifies an accuracy value to help decide whether a result is worthwhile. Tweaking the value is very depedant on corpus and size of corpus.
+                       
+          required: false
+          schema:
+            type: number
+            format: double
+            example: 0.01
+            default: 0.01
+        
         - name: q.op
           in: query
           description: | 

--- a/src/main/openapi/ds-discover-openapi_v1.yaml
+++ b/src/main/openapi/ds-discover-openapi_v1.yaml
@@ -243,7 +243,9 @@ paths:
           description: | 
             Solr spellcheck enabling [spellcheck](https://solr.apache.org/guide/solr/latest/query-guide/spell-checking.html)
             
-            If true, solr response will contain spellcheck information. Spellcheck will only be activated by Solr if no results are found
+            If true, solr response will contain spellcheck information. Spellcheck will only be activated by Solr if no results are found.
+            
+            The spellcheck component will give a query suggesting for another query that will have hits and is close to the original query.
           required: false
           schema:
             type: string
@@ -305,7 +307,7 @@ paths:
         - name: spellcheck.onlyMorePopular 
           in: query
           description: | 
-            If true, Solr will to return suggestions that result in more hits for the query than the existing query 
+            If true, Solr will only return suggestions that result in more hits for the query than the existing query 
                         
           required: false
           schema:

--- a/src/test/java/dk/kb/discover/SolrServiceTest.java
+++ b/src/test/java/dk/kb/discover/SolrServiceTest.java
@@ -26,7 +26,7 @@ class SolrServiceTest {
     //@Test
     void baseSearch() {
         SolrService solr = new SolrService("test", "http://localhost:10007", "solr", "ds");
-        String response = solr.query("*:*", null, null, null, null, null, null, null, null, null, null, null, null, null);
+        String response = solr.query("*:*", null, null, null, null, null, null, null, null, null, null, null, null, null,null,null,null,null,null,null,null,null,null,null,null,null);
         assertTrue(response.contains("responseHeader"), "The Solr response should contain a header");
     }
 


### PR DESCRIPTION
The branch is deployed to devel11 so you can test openAPI.
To test you have to
1) Set spellcheck=true
2) Also set spellcheck.collate=true
All the other spellcheck fields are finetuned and not something frontend will set. But you can try play with them

A good query to testing is **'carin jensen'**
In the solr-response there will be an additional spellcheck json component in the end of the response. 
The only value frontend is interested is the parameters:
   **"collationQuery": "carina jensen",**
Dont worry about the rest.