### PR TITLE
Default parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 - Support for dynamically updating values in OpenAPI spec through internal JIRA issue [DRA-139](https://kb-dk.atlassian.net/browse/DRA-139). 
+- spellcheck.maxCollationRetries=10 is injected per default for Solr /select and /mlt requests [DRA-319](https://kb-dk.atlassian.net/browse/DRA-319)
 
 ## [1.2.2](https://github.com/kb-dk/ds-discover/releases/tag/ds-discover-1.2.2) - 2024-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added 
 - Support for dynamically updating values in OpenAPI spec through internal JIRA issue [DRA-139](https://kb-dk.atlassian.net/browse/DRA-139). 
-- spellcheck.maxCollationRetries=10 is injected per default for Solr /select and /mlt requests [DRA-319](https://kb-dk.atlassian.net/browse/DRA-319)
+- spellcheck.maxCollationRetries=10 is injected per default for Solr /select [DRA-319](https://kb-dk.atlassian.net/browse/DRA-319)
 
 ## [1.2.2](https://github.com/kb-dk/ds-discover/releases/tag/ds-discover-1.2.2) - 2024-03-11
 ### Added

--- a/conf/ds-discover-behaviour.yaml
+++ b/conf/ds-discover-behaviour.yaml
@@ -32,7 +32,7 @@ solr:
       # parameter as default for the /select handler.
       # This param should be made part of solrconfig.xml when the Solr bug
       # has been resolved
-      maxCollationRetries: 10
+      spellcheck.maxCollationRetries: 10
     # Parameters that are forced for all queries, overriding params from the request.
     # The values of the params are either scalars or lists of scalars.
     # The param 'fq' is special as it appends to any existing 'fq' while all other

--- a/conf/ds-discover-behaviour.yaml
+++ b/conf/ds-discover-behaviour.yaml
@@ -14,8 +14,36 @@ limits:
 
 solr:
 
+  # /select specific config
+  select:
+    # Parameters that are default for all queries, but can be overridden by the request.
+    # The values of the params are either scalars or lists of scalars.
+    # Unless there are special reasons not to, default params should be specified
+    # in solrconfig.xml.
+    # The 'fq' param has no special status here: If the request contains 1 or more fq
+    # values, they will override any fq specified under defaultparams.
+    defaultparams:
+      # Compensate for a Solr bug causing crashes when the config has this
+      # parameter as default for the /select handler.
+      # This param should be made part of solrconfig.xml when the Solr bug
+      # has been resolved
+      maxCollationRetries: 10
+    # Parameters that are forced for all queries, overriding params from the request.
+    # The values of the params are either scalars or lists of scalars.
+    # The param 'fq' is special as it appends to any existing 'fq' while all other
+    # params are overwritten
+    forcedparams:
+
+  # /mlt specific config
+  mlt:
+    # Unless there are special reasons not to, default params should be specified
+    # in solrconfig.xml. See solr.select for description of default- and forced-params
+    defaultparams:
+    forcedparams:
+
   shield:
-    # Whether SolrShield is enabled. If false, SolrShield evaluation is still performed but the response is only logged.
+    # Whether SolrShield is enabled.
+    # If false, SolrShield evaluation is still performed but the response is only logged.
     enabled: false
 
     # Current max weight is very likely to be too low for practical use.

--- a/src/main/java/dk/kb/discover/util/SolrParamMerger.java
+++ b/src/main/java/dk/kb/discover/util/SolrParamMerger.java
@@ -59,25 +59,25 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
     }
 
     /**
-     * Convenience method that wraps the given value as a list.
+     * Convenience method that wraps the String representation of the given value as a list.
      * @param key key with which the specified value is to be associated.
-     * @param value value to be associated with the specified key.
+     * @param value value to be associated with the specified key. If null, it will be ignored.
      * @return the previous value that was associated with the key.
      */
-    public List<String> put(String key, String value) {
+    public List<String> put(String key, Object value) {
         failIfFrozen();
         if (value == null) {
             return super.get(key);
         }
-        return super.put(key, Collections.singletonList(value));
+        return super.put(key, Collections.singletonList(Objects.toString(value)));
     }
 
     /**
      * Convenience method for adding all single value parameters in the given {@code map}
-     * as lists of String.
+     * as lists of String representations.
      * @param map mappings to added.
      */
-    public void putAllSingle(Map<? extends String, ? extends String> map) {
+    public void putAllSingle(Map<? extends String, ?> map) {
         failIfFrozen();
         map.forEach(this::put);
     }

--- a/src/main/java/dk/kb/discover/util/SolrParamMerger.java
+++ b/src/main/java/dk/kb/discover/util/SolrParamMerger.java
@@ -21,6 +21,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -31,12 +34,20 @@ import java.util.stream.Collectors;
  * </ul>
  * The map is Solr-aware and treats {@code fq} as special-case, where default {@code fq}s are overridden by
  * user {@code fq}s and forced {@code fq}s merges with all other {@code fq}s.
+ * <p>
+ * Standard use case for the merger is to request an instance from {@link SolrParamMerger.Factory},
+ * add user-provided parameters and used the resulting param map for sending a request to Solr.
+ * <p>
+ * Note that any call to a getter or similar method automatically calls {@link #freeze()}, after which
+ * it is no longer possible to add more parameters. The will be reset if {@code #clear} is called.
  */
 public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
     private static final Logger log = LoggerFactory.getLogger(SolrParamMerger.class);
 
     private final Map<String, List<String>> defaultParams;
     private final Map<String, List<String>> forcedParams;
+
+    private boolean frozen = false;
 
     private SolrParamMerger(Map<String, List<String>> defaultParams,
                             Map<String, List<String>> forcedParams) {
@@ -45,8 +56,202 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
         this.forcedParams = forcedParams;
     }
 
-    
+    /**
+     * Convenience method that wraps the given value as a list.
+     * @param key key with which the specified value is to be associated.
+     * @param value value to be associated with the specified key.
+     * @return the previous value that was associated with the key.
+     */
+    public List<String> put(String key, String value) {
+        failIfFrozen();
+        return super.put(key, Collections.singletonList(value));
+    }
 
+    /**
+     * Convenience method for adding all single value parameters in the given {@code map}
+     * as lists of String.
+     * @param map mappings to added.
+     */
+    public void putAllSingle(Map<? extends String, ? extends String> map) {
+        failIfFrozen();
+        map.forEach(this::put);
+    }
+
+    /**
+     * If frozen, clear unfreezes the merger. Default values are not added after clear.
+     * @see #clear(boolean addDefaultValues)
+     */
+    @Override
+    public void clear() {
+        clear(false);
+    }
+
+    /**
+     * Clears the merger and adds default parameters.
+     * <p>
+     * If frozen, the merger is unfrozen.
+     * @param addDefaultValues if true, {@link #defaultParams} are added after clearing existing values.
+     */
+    public void clear(boolean addDefaultValues) {
+        frozen = false;
+        super.clear();
+        if (addDefaultValues) {
+            putAll(defaultParams);
+        }
+    }
+
+    @Override
+    public List<String> get(Object key) {
+        freeze();
+        return super.get(key);
+    }
+
+    @Override
+    public List<String> getOrDefault(Object key, List<String> defaultValue) {
+        freeze();
+        return super.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        freeze();
+        return super.containsValue(value);
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<String, List<String>> eldest) {
+        freeze();
+        return super.removeEldestEntry(eldest);
+    }
+
+    @Override
+    public Set<String> keySet() {
+        freeze();
+        return super.keySet();
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        freeze();
+        return super.values();
+    }
+
+    @Override
+    public Set<Map.Entry<String, List<String>>> entrySet() {
+        freeze();
+        return super.entrySet();
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super String, ? super List<String>> action) {
+        freeze();
+        super.forEach(action);
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super String, ? super List<String>, ? extends List<String>> function) {
+        freeze();
+        super.replaceAll(function);
+    }
+
+    @Override
+    public List<String> put(String key, List<String> value) {
+        failIfFrozen();
+        return super.put(key, value);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends List<String>> m) {
+        failIfFrozen();
+        super.putAll(m);
+    }
+
+    @Override
+    public List<String> putIfAbsent(String key, List<String> value) {
+        failIfFrozen();
+        return super.putIfAbsent(key, value);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        failIfFrozen();
+        return super.remove(key, value);
+    }
+
+    @Override
+    public boolean replace(String key, List<String> oldValue, List<String> newValue) {
+        failIfFrozen();
+        return super.replace(key, oldValue, newValue);
+    }
+
+    @Override
+    public List<String> replace(String key, List<String> value) {
+        failIfFrozen();
+        return super.replace(key, value);
+    }
+
+    @Override
+    public List<String> computeIfAbsent(String key, Function<? super String, ? extends List<String>> mappingFunction) {
+        failIfFrozen();
+        return super.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public List<String> computeIfPresent(String key, BiFunction<? super String, ? super List<String>, ? extends List<String>> remappingFunction) {
+        failIfFrozen();
+        return super.computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public List<String> compute(String key, BiFunction<? super String, ? super List<String>, ? extends List<String>> remappingFunction) {
+        failIfFrozen();
+        return super.compute(key, remappingFunction);
+    }
+
+    @Override
+    public List<String> merge(String key, List<String> value, BiFunction<? super List<String>, ? super List<String>, ? extends List<String>> remappingFunction) {
+        failIfFrozen();
+        return super.merge(key, value, remappingFunction);
+    }
+
+    /**
+     * Covenience method that throws an exception if the merger has been frozen.
+     * Called from mutators.
+     */
+    private void failIfFrozen() {
+        if (frozen) {
+            throw new IllegalStateException("Mutator method called on frozen merger." +
+                                            "All mutations must have finished before any getters are called");
+        }
+    }
+
+    /**
+     * Apply forced parameters, effectively finalizing the params for use.
+     * <p>
+     * After freezing it is no longer possible to add parameters.
+     */
+    private void freeze() {
+        if (frozen) {
+            return;
+        }
+        forcedParams.forEach((k, v) -> {
+            if ("fq".equals(k)) { // Forced fq is additive as Solr fq's always stack
+                if (containsKey("fq")) {
+                    List<String> fq = new ArrayList<>(get("fq")); // Ensure the list is mutable
+                    fq.addAll(v);
+                    put("fq", fq);
+                    return;
+                }
+            }
+            put(k, v);
+        });
+        frozen = true;
+    }
+
+
+    /**
+     * Cached default- and forced-params for cheap construction of {@link SolrParamMerger}s.
+     */
     public static class Factory {
         private final Map<String, List<String>> defaultParams;
         private final Map<String, List<String>> forcedParams;
@@ -75,11 +280,11 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
          *     # params are overwritten
          *     forcedparams:
          * </pre>
-         * @param handler a Solr handler as specified in the configuration.
+         * @param handler a Solr handler as specified in the configuration, i.e. {@code select} or {@code mlt}.
          */
         public Factory(String handler) {
-            defaultParams = getParams("select.defaultparams");
-            forcedParams = getParams("select.forcedparams");
+            defaultParams = getParams(handler + ".defaultparams");
+            forcedParams = getParams(handler + ".forcedparams");
         }
 
         /**
@@ -111,28 +316,24 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
                     .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
         }
 
-        /**
-         * Create a new merger for the given handler. Handlers are defined in the application configuration.
-         * <p>
-         * When the addition of user provided parameters to the merger has finished, call {@link SolrParamMerger#applyForced}
-         * before extracting values from the merger.
-         * @return a new merger ready for receiving user provided parameters.
-         */
-        public static SolrParamMerger createMerger(String handler) {
-        }
     }
 
     /**
-     * Converts entries to pairs, with conversion of arrays to lists.
+     * Converts entries to pairs, with conversion of arrays and lists to String lists.
      * @param entry a Solr param entry.
      * @return a key-value pair with the entry data or null if {@link Map.Entry#getValue()} is an empty String array.
      */
     private static Pair<String, List<String>> toPair(Map.Entry<String, Object> entry) {
+        List<String> vals;
         if (entry.getValue() instanceof String[]) {
-            String[] vals = (String[])entry.getValue();
-            return vals.length == 0 ? null :
-                    new Pair<>(entry.getKey(), Arrays.asList(vals));
+            vals = Arrays.asList((String[])entry.getValue());
+        } else if (entry.getValue() instanceof List) {
+            vals = ((List<?>)entry.getValue()).stream()
+                    .map(Objects::toString)
+                    .collect(Collectors.toList());
+        } else {
+            vals = Collections.singletonList(Objects.toString(entry.getValue()));
         }
-        return new Pair<>(entry.getKey(), Collections.singletonList(Objects.toString(entry.getValue())));
+        return vals.isEmpty() ? null : new Pair<>(entry.getKey(), vals);
     }
 }

--- a/src/main/java/dk/kb/discover/util/SolrParamMerger.java
+++ b/src/main/java/dk/kb/discover/util/SolrParamMerger.java
@@ -67,7 +67,7 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
      */
     public List<String> put(String key, Object value) {
         failIfFrozen();
-        if (value == null) {
+        if (value == null || Objects.toString(value).isEmpty()) {
             return super.get(key);
         }
         return super.put(key, Collections.singletonList(Objects.toString(value)));
@@ -92,6 +92,9 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
         }
         if (value.getClass().isArray()) { // int[], boolean[] etc.
             throw new UnsupportedOperationException("Adding atomic arrays is not currently supported");
+        }
+        if (Objects.toString(value).isEmpty()) {
+            return super.get(key);
         }
         ArrayList<String> values = super.containsKey(key) ?
                 new ArrayList<>(super.get(key)) :

--- a/src/main/java/dk/kb/discover/util/SolrParamMerger.java
+++ b/src/main/java/dk/kb/discover/util/SolrParamMerger.java
@@ -35,6 +35,8 @@ import java.util.stream.Collectors;
  * The map is Solr-aware and treats {@code fq} as special-case, where default {@code fq}s are overridden by
  * user {@code fq}s and forced {@code fq}s merges with all other {@code fq}s.
  * <p>
+ * The map ignores attempts of adding {@code null} values.
+ * <p>
  * Standard use case for the merger is to request an instance from {@link SolrParamMerger.Factory},
  * add user-provided parameters and used the resulting param map for sending a request to Solr.
  * <p>
@@ -64,6 +66,9 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
      */
     public List<String> put(String key, String value) {
         failIfFrozen();
+        if (value == null) {
+            return super.get(key);
+        }
         return super.put(key, Collections.singletonList(value));
     }
 
@@ -157,37 +162,49 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
     @Override
     public List<String> put(String key, List<String> value) {
         failIfFrozen();
+        if (value == null || value.isEmpty()) {
+            return super.get(key);
+        }
         return super.put(key, value);
     }
 
     @Override
     public void putAll(Map<? extends String, ? extends List<String>> m) {
         failIfFrozen();
-        super.putAll(m);
+        m.forEach(this::put);
     }
 
     @Override
     public List<String> putIfAbsent(String key, List<String> value) {
         failIfFrozen();
+        if (value == null || value.isEmpty()) {
+            return super.get(key);
+        }
         return super.putIfAbsent(key, value);
-    }
-
-    @Override
-    public boolean remove(Object key, Object value) {
-        failIfFrozen();
-        return super.remove(key, value);
     }
 
     @Override
     public boolean replace(String key, List<String> oldValue, List<String> newValue) {
         failIfFrozen();
+        if (newValue == null || newValue.isEmpty()) {
+            return false;
+        }
         return super.replace(key, oldValue, newValue);
     }
 
     @Override
     public List<String> replace(String key, List<String> value) {
         failIfFrozen();
+        if (value == null || value.isEmpty()) {
+            return super.get(key);
+        }
         return super.replace(key, value);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        failIfFrozen();
+        return super.remove(key, value);
     }
 
     @Override

--- a/src/main/java/dk/kb/discover/util/SolrParamMerger.java
+++ b/src/main/java/dk/kb/discover/util/SolrParamMerger.java
@@ -73,6 +73,42 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
     }
 
     /**
+     * Convenience method that adds the given value to the existing values (if any) for the given key.
+     * @param key key with which the specified value is to be associated.
+     * @param value value to be associated with the specified key. If null, it will be ignored.
+     * @return the previous values that were associated with the key.
+     */
+    public List<String> add(String key, Object value) {
+        failIfFrozen();
+        if (value == null) {
+            return super.get(key);
+        }
+        ArrayList<String> values = super.containsValue(key) ?
+                new ArrayList<>(super.get(key)) :
+                new ArrayList<>();
+        values.add(Objects.toString(value));
+        return super.put(key, values);
+    }
+
+    /**
+     * Convenience method that adds the given values to the existing values (if any) for the given key.
+     * @param key key with which the specified value is to be associated.
+     * @param values value to be associated with the specified key. If null, it will be ignored.
+     * @return the previous values that were associated with the key.
+     */
+    public List<String> add(String key, List<String> values) {
+        failIfFrozen();
+        if (values == null || values.isEmpty()) {
+            return super.get(key);
+        }
+        ArrayList<String> merged = super.containsValue(key) ?
+                new ArrayList<>(super.get(key)) :
+                new ArrayList<>();
+        merged.addAll(values);
+        return super.put(key, merged);
+    }
+
+    /**
      * Convenience method for adding all single value parameters in the given {@code map}
      * as lists of String representations.
      * @param map mappings to added.
@@ -265,6 +301,9 @@ public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
         frozen = true;
     }
 
+    public boolean isFrozen() {
+        return frozen;
+    }
 
     /**
      * Cached default- and forced-params for cheap construction of {@link SolrParamMerger}s.

--- a/src/main/java/dk/kb/discover/util/SolrParamMerger.java
+++ b/src/main/java/dk/kb/discover/util/SolrParamMerger.java
@@ -1,0 +1,138 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.discover.util;
+
+import dk.kb.discover.config.ServiceConfig;
+import dk.kb.util.Pair;
+import dk.kb.util.yaml.YAML;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Special purpose map that supports
+ * <ul>
+ *     <li>Default values that can be overridden by user values</li>
+ *     <li>Forced values that overrides user values</li>
+ * </ul>
+ * The map is Solr-aware and treats {@code fq} as special-case, where default {@code fq}s are overridden by
+ * user {@code fq}s and forced {@code fq}s merges with all other {@code fq}s.
+ */
+public class SolrParamMerger extends LinkedHashMap<String, List<String>> {
+    private static final Logger log = LoggerFactory.getLogger(SolrParamMerger.class);
+
+    private final Map<String, List<String>> defaultParams;
+    private final Map<String, List<String>> forcedParams;
+
+    private SolrParamMerger(Map<String, List<String>> defaultParams,
+                            Map<String, List<String>> forcedParams) {
+        this.defaultParams = defaultParams;
+        putAll(defaultParams);
+        this.forcedParams = forcedParams;
+    }
+
+    
+
+    public static class Factory {
+        private final Map<String, List<String>> defaultParams;
+        private final Map<String, List<String>> forcedParams;
+
+        /**
+         * Create a merger factory for the given handler. Handlers are defined in the application configuration:
+         * <pre>
+         *solr:
+         *   # /select specific config
+         *   select:
+         *     # Parameters that are default for all queries, but can be overridden by the request.
+         *     # The values of the params are either scalars or lists of scalars.
+         *     # Unless there are special reasons not to, default params should be specified
+         *     # in solrconfig.xml.
+         *     # The 'fq' param has no special status here: If the request contains 1 or more fq
+         *     # values, they will override any fq specified under defaultparams.
+         *     defaultparams:
+         *       # Compensate for a Solr bug causing crashes when the config has this
+         *       # parameter as default for the /select handler.
+         *       # This param should be made part of solrconfig.xml when the Solr bug
+         *       # has been resolved
+         *       maxCollationRetries: 10
+         *     # Parameters that are forced for all queries, overriding params from the request.
+         *     # The values of the params are either scalars or lists of scalars.
+         *     # The param 'fq' is special as it appends to any existing 'fq' while all other
+         *     # params are overwritten
+         *     forcedparams:
+         * </pre>
+         * @param handler a Solr handler as specified in the configuration.
+         */
+        public Factory(String handler) {
+            defaultParams = getParams("select.defaultparams");
+            forcedParams = getParams("select.forcedparams");
+        }
+
+        /**
+         * Create a merger, ready for adding user provided params.
+         * @return a merger ready for input.
+         */
+        public SolrParamMerger createMerger() {
+            return new SolrParamMerger(defaultParams, forcedParams);
+        }
+
+        /**
+         * Create a Solr param map from the given YAML path.
+         * @param yPath the location in the config for the params.
+         * @return a Solr param map.
+         */
+        private Map<String, List<String>> getParams(String yPath) {
+            YAML conf = ServiceConfig.getConfig().containsKey(yPath) ?
+                    ServiceConfig.getConfig().getYAML(yPath) :
+                    null;
+            if (conf == null) {
+                return Collections.emptyMap();
+            }
+
+            return conf.entrySet().stream()
+                    .filter(e -> e.getValue() != null)
+                    .filter(e -> !e.getValue().toString().isEmpty())
+                    .map(SolrParamMerger::toPair)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+        }
+
+        /**
+         * Create a new merger for the given handler. Handlers are defined in the application configuration.
+         * <p>
+         * When the addition of user provided parameters to the merger has finished, call {@link SolrParamMerger#applyForced}
+         * before extracting values from the merger.
+         * @return a new merger ready for receiving user provided parameters.
+         */
+        public static SolrParamMerger createMerger(String handler) {
+        }
+    }
+
+    /**
+     * Converts entries to pairs, with conversion of arrays to lists.
+     * @param entry a Solr param entry.
+     * @return a key-value pair with the entry data or null if {@link Map.Entry#getValue()} is an empty String array.
+     */
+    private static Pair<String, List<String>> toPair(Map.Entry<String, Object> entry) {
+        if (entry.getValue() instanceof String[]) {
+            String[] vals = (String[])entry.getValue();
+            return vals.length == 0 ? null :
+                    new Pair<>(entry.getKey(), Arrays.asList(vals));
+        }
+        return new Pair<>(entry.getKey(), Collections.singletonList(Objects.toString(entry.getValue())));
+    }
+}

--- a/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
+++ b/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,6 +34,29 @@ class SolrParamMergerTest {
     public void testDefaultsNoExtra() {
         SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
         assertEquals("foo", merger.get("fq").get(0));
+    }
+
+    @Test
+    public void testPutPutSingle() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        merger.put("foo", "bar");
+        merger.put("boom", "baz");
+    }
+
+    @Test
+    public void testPutNothing() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        merger.put("foo", "bar");
+        merger.put("foo", (String)null);
+        merger.put("foo", Collections.emptyList());
+        assertEquals("[bar]", merger.get("foo").toString());
+    }
+
+    @Test
+    public void testPutPutList() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        merger.put("foo", Collections.singletonList("bar"));
+        merger.put("boom", Collections.singletonList("baz"));
     }
 
     @Test

--- a/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
+++ b/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
@@ -53,10 +53,19 @@ class SolrParamMergerTest {
     }
 
     @Test
+    public void testPutInteger() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        merger.put("foo", 10);
+        assertEquals("[10]", merger.get("foo").toString());
+    }
+
+    @Test
     public void testPutPutList() {
         SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
         merger.put("foo", Collections.singletonList("bar"));
         merger.put("boom", Collections.singletonList("baz"));
+        assertEquals("[bar]", merger.get("foo").toString());
+        assertEquals("[baz]", merger.get("boom").toString());
     }
 
     @Test

--- a/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
+++ b/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
@@ -1,0 +1,108 @@
+package dk.kb.discover.util;
+
+import dk.kb.discover.config.ServiceConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+class SolrParamMergerTest {
+
+    @BeforeAll
+    public static void setup() throws IOException {
+        ServiceConfig.initialize("solrparammerger-test.yaml");
+    }
+
+    @Test
+    public void testDefaultsNoExtra() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        assertEquals("foo", merger.get("fq").get(0));
+    }
+
+    @Test
+    public void testDefaultsOverride() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        merger.put("fq", "zoo");
+        assertEquals("zoo", merger.get("fq").get(0));
+    }
+
+    @Test
+    public void testForceNoExtra() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select2").createMerger();
+        assertEquals("bar", merger.get("fq").get(0));
+    }
+
+    @Test
+    public void testForceAdd() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select2").createMerger();
+        merger.put("fq", "zoo");
+        assertEquals("[zoo, bar]", merger.get("fq").toString());
+    }
+
+    @Test
+    public void testDefaultAndForceNoExra() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select3").createMerger();
+        assertEquals("[foo, bar]", merger.get("fq").toString());
+    }
+
+    @Test
+    public void testDefaultAndForceAdd() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select3").createMerger();
+        merger.put("fq", "zoo");
+        assertEquals("[zoo, bar]", merger.get("fq").toString());
+    }
+
+    @Test
+    public void testForceSimpleAdd() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select3").createMerger();
+        merger.put("rows", "20");
+        assertEquals("[10]", merger.get("rows").toString());
+    }
+
+    @Test
+    public void testIllegalState() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        merger.put("fq", "zoo");
+        merger.get("fq");
+        assertThrows(IllegalStateException.class, () -> merger.put("fq", "baz"));
+    }
+
+    @Test
+    public void testClear() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        merger.put("fq", "zoo");
+        merger.get("fq");
+        assertTrue(merger.containsKey("maxCollationRetries"),
+                    "Before clear there should be a maxCollationRetries");
+        merger.clear();
+        merger.put("fq", "baz"); // Throws without clear in testIllegalState
+        assertFalse(merger.containsKey("maxCollationRetries"),
+                    "After clear there should be no maxCollationRetries");
+    }
+
+    @Test
+    public void testClearAdd() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        assertTrue(merger.containsKey("maxCollationRetries"),
+                    "Before clear(true) there should be a maxCollationRetries");
+        merger.clear(true);
+        assertTrue(merger.containsKey("maxCollationRetries"),
+                    "After clear(true) there should be a maxCollationRetries");
+    }
+}

--- a/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
+++ b/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -41,6 +42,24 @@ class SolrParamMergerTest {
         SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
         merger.put("foo", "bar");
         merger.put("boom", "baz");
+    }
+
+    @Test
+    public void testAddSingle() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        assertFalse(merger.isFrozen());
+        merger.add("foo", "bar");
+        merger.add("foo", "baz");
+        assertEquals("[bar, baz]", merger.get("foo").toString());
+    }
+
+    @Test
+    public void testAddMulti() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        assertFalse(merger.isFrozen());
+        merger.add("foo", "bar");
+        merger.add("foo", List.of("baz", "zoo"));
+        assertEquals("[bar, baz, zoo]", merger.get("foo").toString());
     }
 
     @Test

--- a/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
+++ b/src/test/java/dk/kb/discover/util/SolrParamMergerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -108,7 +109,7 @@ class SolrParamMergerTest {
     }
 
     @Test
-    public void testDefaultAndForceNoExra() {
+    public void testDefaultAndForceNoExtra() {
         SolrParamMerger merger = new SolrParamMerger.Factory("select3").createMerger();
         assertEquals("[foo, bar]", merger.get("fq").toString());
     }
@@ -157,4 +158,15 @@ class SolrParamMergerTest {
         assertTrue(merger.containsKey("maxCollationRetries"),
                     "After clear(true) there should be a maxCollationRetries");
     }
+
+    @Test
+    public void testAddMixedMap() {
+        SolrParamMerger merger = new SolrParamMerger.Factory("select1").createMerger();
+        merger.addAll(Map.of("fq", "bar"));
+        merger.addAll(Map.of("fq", new Integer[]{1, 2}));
+        //merger.addAll(Map.of("fq", new int[]{3, 4})); // Not supported (yet)
+        merger.addAll(Map.of("fq", List.of(true, false)));
+        assertEquals("[foo, bar, 1, 2, true, false]", merger.get("fq").toString());
+    }
+
 }

--- a/src/test/resources/solrparammerger-test.yaml
+++ b/src/test/resources/solrparammerger-test.yaml
@@ -1,0 +1,18 @@
+solr:
+  select1:
+    defaultparams:
+      fq: foo
+      maxCollationRetries: 10
+    forcedparams:
+
+  select2:
+    forcedparams:
+      fq: bar
+
+  select3:
+    defaultparams:
+      fq: foo
+    forcedparams:
+      fq: bar
+      rows: 10
+


### PR DESCRIPTION
This pull request adds two mechanism for adjusting solr request parameters:

* `default` parameters are present before user provided parameters are applied. They are overwritten by the user parameters
* `forced` parameters overrides user parameters

The setup is controlled by the standard configuration system and `ds-discover-behaviour` has been extended with `spellcheck.maxCollationRetries=10` for the `/select` handler, thereby compensating for the Solr bug that prohibits using `spellcheck.maxCollationRetries` as default parameter.

The logic for handling `default`-, `user-` and `forced`-parameters is in the class `SolrParamMerger`. as a consequence, `SolrService` is a bit simpler now.