### PR TITLE
Bugfix: Switch from Jersey to Apache URI Builder to handle parameters containing '{'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for dynamically updating values in OpenAPI spec through internal JIRA issue [DRA-139](https://kb-dk.atlassian.net/browse/DRA-139). 
 - spellcheck.maxCollationRetries=10 is injected per default for Solr /select [DRA-319](https://kb-dk.atlassian.net/browse/DRA-319)
 
+### Fixed
+- Switch from Jersey to Apache URI Builder to handle parameters containing '{' [DRA-338](https://kb-dk.atlassian.net/browse/DRA-338)
+
 ## [1.2.2](https://github.com/kb-dk/ds-discover/releases/tag/ds-discover-1.2.2) - 2024-03-11
 ### Added
 - SolrShield implemented for basic search + facet. Currently set to log the result instead of potentially rejecting calls to select/


### PR DESCRIPTION
Jersey's `UriBuilder` treats `{` as the signal for an expansion mechanism, making requests containing `{` fail. This pull request switches to Apache's `URIBuilder`.

Easily tested by issuing a query for `hest {` or similar.