### PR TITLE
DRA-925

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Yaml configuration updated with list of additional allowed Solr query parameters (solr.extraAllowedParameters). SolrShield will also allow these parameters can be returned from Solr.
+
 
 ## [1.2.4](https://github.com/kb-dk/ds-discover/releases/tag/ds-discover-1.2.4) - 2024-06-12
 ### Changed

--- a/conf/ds-discover-behaviour.yaml
+++ b/conf/ds-discover-behaviour.yaml
@@ -17,6 +17,13 @@ openapi:
 
 solr:
 
+  #Additional parameters allowed to be sent to solr. 
+  extraAllowedParameters:
+    # queryUUID is returned to the frontend and used as session tracking.
+    - queryUUID 
+    # Frontend uses facet.limit this for timeline
+    - facet.limit
+
   # /select specific config
   select:
     # Parameters that are default for all queries, but can be overridden by the request.

--- a/src/main/java/dk/kb/discover/util/solrshield/Profile.java
+++ b/src/main/java/dk/kb/discover/util/solrshield/Profile.java
@@ -14,6 +14,7 @@
  */
 package dk.kb.discover.util.solrshield;
 
+import dk.kb.discover.config.ServiceConfig;
 import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +22,8 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * Representation of a given profile for SolrShield.
@@ -159,8 +162,10 @@ public class Profile extends ProfileElement<Profile> {
         Profile clone = deepCopy();
         Set<String> processedKeys = new HashSet<>();
         processedKeys.addAll(clone.search.apply(request));
-        processedKeys.addAll(clone.facet.apply(request));
-
+        processedKeys.addAll(clone.facet.apply(request));                
+        List<String> extraAllowedParameters = ServiceConfig.getConfig().getList("solr.extraAllowedParameters"); //The value are also checked when sending the solr request.
+        processedKeys.addAll(extraAllowedParameters);       
+        
         clone.unhandledParams =
                 StreamSupport.stream(request.spliterator(), false)
                         .filter(e -> !processedKeys.contains(e.getKey()))


### PR DESCRIPTION
Additional allowed query parameters can be allowed in calls to Solr. The additional parameters will also be allowed in SolrShield when they are present in the response from Solr.

The new yaml property is: "solr.extraAllowedParameters". queryUUID and facet.limit has been added as defaults