### PR TITLE
Removed autogenerated client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped SwaggerUI dependency to v5.18.2
 - Bumped multiple OpenAPI dependency versions
 - Added injection of Oauth token on all service methods when using DsDiscoverClient. But no methods for new are exposed in the client.
-- Bumped kb-util to v1.6.8 for service2service oauth support.
-
+- Bumped kb-util to v1.6.9 for service2service oauth support.
+- Removed auto generated DsLicenseClient class that was a blocker for better exception handling. All DsLicenseClient methods now only throws ServiceException mapped to HTTP status in same way calling the API directly.
+-
 
 ### Fixed
 - Fixed /api-docs wrongly showing petstore example API spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped multiple OpenAPI dependency versions
 - Added injection of Oauth token on all service methods when using DsDiscoverClient. But no methods for new are exposed in the client.
 - Bumped kb-util to v1.6.9 for service2service oauth support.
-- Removed auto generated DsLicenseClient class that was a blocker for better exception handling. All DsLicenseClient methods now only throws ServiceException mapped to HTTP status in same way calling the API directly.
+- Removed auto generated DsDiscoverClient class that was a blocker for better exception handling. All DsDiscoverClient methods now only throws ServiceException mapped to HTTP status in same way calling the API directly.
 -
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -307,8 +307,11 @@
             <version>2.8.9</version>
         </dependency>
 
-
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.4.2</version>
+         </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.6.8</version>
+            <version>1.6.9</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -459,43 +459,6 @@
                         </configuration>
                     </execution>
 
-                    <!-- Client for ds-discover -->
-                    <execution>
-                        <id>Generate client for JAR package and use by other services</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <inputSpec>${project.build.outputDirectory}/ds-discover-openapi_v1.yaml</inputSpec>
-                            <ignoreFileOverride>${project.basedir}/.openapi-codegen-ignore-api</ignoreFileOverride>
-                            <generatorName>java</generatorName>
-                            <library>native</library>
-
-                            <!-- Do not generate doc or tests for this client, we will handle this ourselves-->
-                            <generateApis>true</generateApis>
-                            <generateApiTests>false</generateApiTests>
-                            <generateApiDocumentation>false</generateApiDocumentation>
-                            <generateModels>false</generateModels>
-                            <generateModelTests>false</generateModelTests>
-                            <generateModelDocumentation>false</generateModelDocumentation>
-
-                            <!-- Ensure ONLY the ApiClient and supporting classes are created, not the gradle mess-->
-                            <generateSupportingFiles>true</generateSupportingFiles>
-                            <supportingFilesToGenerate>ApiClient.java,ApiException.java,Configuration.java,Pair.java</supportingFilesToGenerate>
-
-                            <!-- Do NOT use the customised templates as they are only for the webservice part, not the client-->
-                            <!-- Hacked by Asger by setting to an existing folder without templates -->
-                            <templateDirectory>src/main/</templateDirectory>
-
-                            <configOptions>
-                                <apiPackage>${project.package}.client.v1</apiPackage>
-                                <modelPackage>${project.package}.model.v1</modelPackage>
-                                <invokerPackage>${project.package}.invoker.v1</invokerPackage>
-                                <sourceFolder>target/generated-sources</sourceFolder>
-                                <implFolder>target/generated-sources</implFolder>
-                            </configOptions>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
 

--- a/src/main/java/dk/kb/discover/SolrService.java
+++ b/src/main/java/dk/kb/discover/SolrService.java
@@ -22,9 +22,9 @@ import dk.kb.discover.util.LicenseUtil;
 import dk.kb.discover.util.SolrParamMerger;
 import dk.kb.discover.util.SolrSuggestLimiter;
 import dk.kb.discover.util.responses.suggest.SuggestResponse;
-import dk.kb.license.client.v1.DsLicenseApi;
 import dk.kb.license.model.v1.GetUserQueryInputDto;
 import dk.kb.license.model.v1.GetUsersFilterQueryOutputDto;
+import dk.kb.license.util.DsLicenseClient;
 import dk.kb.util.other.StringListUtils;
 import dk.kb.util.webservice.exception.InternalServiceException;
 import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
@@ -694,7 +694,7 @@ public class SolrService {
      */
     public List<String> createAccessFilter(String designation) {
         //Add filter query from license module.
-        DsLicenseApi licenseClient = LicenseUtil.getDsLicenseApiClient();
+        DsLicenseClient licenseClient = LicenseUtil.getDsLicenseApiClient();
         GetUserQueryInputDto licenseQueryDto = LicenseUtil.getLicenseQueryDto();
         GetUsersFilterQueryOutputDto filterQuery;
         try {

--- a/src/main/java/dk/kb/discover/api/v1/impl/DsDiscoverApiServiceImpl.java
+++ b/src/main/java/dk/kb/discover/api/v1/impl/DsDiscoverApiServiceImpl.java
@@ -34,7 +34,6 @@ import dk.kb.discover.SolrManager;
 import dk.kb.discover.SolrService;
 import dk.kb.discover.api.v1.DsDiscoverApi;
 import dk.kb.discover.config.ServiceConfig;
-import dk.kb.license.client.v1.DsLicenseApi;
 import dk.kb.license.model.v1.GetUserQueryInputDto;
 import dk.kb.license.model.v1.GetUsersFilterQueryOutputDto;
 import dk.kb.license.model.v1.UserObjAttributeDto;
@@ -108,7 +107,7 @@ public class DsDiscoverApiServiceImpl extends ImplBase implements DsDiscoverApi 
     private transient MessageContext messageContext;
 
 
-    private static DsLicenseApi licenseClient;  
+    private static DsLicenseClient licenseClient;  
     
     /**
      * Solr [Collection Management Commands](https://solr.apache.org/guide/8_10/collection-management.html)
@@ -370,7 +369,7 @@ public class DsDiscoverApiServiceImpl extends ImplBase implements DsDiscoverApi 
      */
     private List<String> addAccessFilter(String designation, List<String> fq) {
         //Add filter query from license module.
-        DsLicenseApi licenseClient = getDsLicenseApiClient();
+        DsLicenseClient licenseClient = getDsLicenseApiClient();
         GetUserQueryInputDto licenseQueryDto = getLicenseQueryDto();
         GetUsersFilterQueryOutputDto filterQuery;
         try {
@@ -408,7 +407,7 @@ public class DsDiscoverApiServiceImpl extends ImplBase implements DsDiscoverApi 
        return LicenseUtil.getLicenseQueryDto();
     }
     
-    private static DsLicenseApi getDsLicenseApiClient() {
+    private static DsLicenseClient getDsLicenseApiClient() {
         return LicenseUtil.getDsLicenseApiClient();
     }
     

--- a/src/main/java/dk/kb/discover/util/DsDiscoverClient.java
+++ b/src/main/java/dk/kb/discover/util/DsDiscoverClient.java
@@ -14,10 +14,6 @@
  */
 package dk.kb.discover.util;
 
-import dk.kb.discover.client.v1.DsDiscoverApi;
-import dk.kb.discover.invoker.v1.ApiClient;
-import dk.kb.discover.invoker.v1.ApiException;
-import dk.kb.discover.invoker.v1.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +29,7 @@ import java.util.List;
  * The client is Thread safe and handles parallel requests independently.
  * It is recommended to persist the client and to re-use it between calls.
  */
-public class DsDiscoverClient extends DsDiscoverApi {
+public class DsDiscoverClient  {
     private static final Logger log = LoggerFactory.getLogger(DsDiscoverClient.class);
 
     /**
@@ -41,60 +37,8 @@ public class DsDiscoverClient extends DsDiscoverApi {
      * @param serviceURI the URI for the service, e.g. {@code https://example.com/ds-discover/v1}.
      */
     public DsDiscoverClient(String serviceURI) {
-        super(createClient(serviceURI));
         log.info("Created OpenAPI client for '" + serviceURI + "'");
     }
-
-    /**
-     * Deconstruct the given URI and use the components to create an ApiClient.
-     * @param serviceURIString an URI to a service.
-     * @return an ApiClient constructed from the serviceURIString.
-     */
-    private static ApiClient createClient(String serviceURIString) {
-        log.debug("Creating OpenAPI client with URI '{}'", serviceURIString);
-
-        URI serviceURI = URI.create(serviceURIString);
-        // No mechanism for just providing the full URI. We have to deconstruct it
-        return Configuration.getDefaultApiClient().
-                setScheme(serviceURI.getScheme()).
-                setHost(serviceURI.getHost()).
-                setPort(serviceURI.getPort()).
-                setBasePath(serviceURI.getRawPath());
-    }
-    
-    @Override
-    public String configAction (String action, String name) throws ApiException {
-        throw new ApiException(403, "Method configAction not allowed to be called on DsDiscoverClient");
-    }
-    
-     @Override
-    public String collectionAction (String action, String name, String async) throws ApiException {
-         throw new ApiException(403, "Method collectionAction  not allowed to be called on DsDiscoverClient");        
-     }
-           
-     @Override
-     public String documentedSchema (String collection, String format) throws ApiException {
-         throw new ApiException(403, "Method documentedSchema not allowed to be called on DsDiscoverClient");
-     }
-         
-     @Override
-     public String solrMLT (String collection, String q, String mltFl, Integer mltMintf, Integer mltMindf, Integer mltMaxdf, Integer mltMaxdfpct, Integer mltMinwl, Integer mltMaxwl, Integer mltMaxqt, Boolean mltBoost, String mltInterestingTerms, List<String> fq, Integer rows, Integer start, String fl, String qOp, String wt) throws ApiException {
-         throw new ApiException(403, "Method solrMLT not allowed to be called on DsDiscoverClient");        
-     }
-         
-     @Override
-     public String solrSchema (String collection, String wt) throws ApiException {
-         throw new ApiException(403, "Method solrSchema not allowed to be called on DsDiscoverClient");         
-     }
-         
-     @Override
-     public String solrSearch (String collection, String q, List<String> fq, Integer rows, Integer start, String fl, String facet, List<String> facetField, String spellcheck, String spellcheckBuild, String spellcheckReload, String spellcheckQ, String spellcheckDictionary, Integer spellcheckCount, String spellcheckOnlyMorePopular, String spellcheckExtendedResults, String spellcheckCollate, Integer spellcheckMaxCollations, Integer spellcheckMaxCollationTries, Double spellcheckAccuracy, String qOp, String wt, String version, String indent, String debug, String debugExplainStructured) throws ApiException {
-         throw new ApiException(403, "Method  solrSearch not allowed to be called on DsDiscoverClient");              
-     }
-     
-     @Override
-     public String solrSuggest (String collection, String suggestDictionary, String suggestQ, Integer suggestCount, String wt) throws ApiException {
-         throw new ApiException(403, "Method solrSuggest not allowed to be called on DsDiscoverClient");  
-     }
+        
      
 }

--- a/src/main/java/dk/kb/discover/util/LicenseUtil.java
+++ b/src/main/java/dk/kb/discover/util/LicenseUtil.java
@@ -1,7 +1,6 @@
 package dk.kb.discover.util;
 
 import dk.kb.discover.config.ServiceConfig;
-import dk.kb.license.client.v1.DsLicenseApi;
 import dk.kb.license.model.v1.GetUserQueryInputDto;
 import dk.kb.license.model.v1.UserObjAttributeDto;
 import dk.kb.license.util.DsLicenseClient;
@@ -10,10 +9,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class LicenseUtil {
-    private static DsLicenseApi licenseClient;
+    private static DsLicenseClient licenseClient;
 
 
-    public static DsLicenseApi getDsLicenseApiClient() {
+    public static DsLicenseClient  getDsLicenseApiClient() {
 
         if (licenseClient!= null) {
             return licenseClient;


### PR DESCRIPTION
See ds-license for description: https://github.com/kb-dk/ds-license/pull/43/
All ds-module will have autogenerated client removed.

Notice: 
No API methods has been implemented on ds-discover client. 

