### PR TITLE
DRA-2708-minimum-client-jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+  - Create minimum client jar. Cross module dependencies uses this new jar instead of the full classes jar.
   - Per-collection SolrShield support. Each Solr collection in `ds-discover-behaviour.yaml`
     may now declare its own shield via a new optional `shield:` key pointing at a standalone
     shield YAML (path absolute or relative to the `ds-discover-*.yaml` files). Collections

--- a/pom.xml
+++ b/pom.xml
@@ -56,42 +56,28 @@
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
-        <!-- Client for ds-license. This will also require the org.openapitools dependency-->
-        <dependency>
+     <dependency>
             <groupId>dk.kb.license</groupId>
             <artifactId>ds-license</artifactId>
             <version>100.0.0-SNAPSHOT</version>
             <type>jar</type>
-            <classifier>classes</classifier>
+            <classifier>api</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
+       </dependency>
+       <dependency>
             <groupId>dk.kb.present</groupId>
             <artifactId>ds-present</artifactId>
             <version>100.0.0-SNAPSHOT</version>
             <type>jar</type>
-            <classifier>classes</classifier>
+            <classifier>api</classifier>
             <exclusions>
                 <exclusion>
-                    <groupId>dk.kb.storage</groupId>
-                    <artifactId>ds-storage</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.github.ben-manes.caffeine</groupId>
-                    <artifactId>caffeine</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.poi</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.solr</groupId>
+                    <groupId>*</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
@@ -423,9 +409,8 @@
                         </manifest>
                     </archive>
 
-                    <!-- Generate a JAR with client classes and openapi-YAML for easy use by other services -->
-                    <attachClasses>true</attachClasses>
-
+                   <!-- Generation of API jar is done in seperate plugin and only contains DTOs and client class -->                    
+                   <!-- <attachClasses>true</attachClasses> --> 
                     <!--Enable maven filtering for the web.xml-->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
                     <webResources>
@@ -449,6 +434,27 @@
                 </configuration>
             </plugin>
 
+
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>            
+               <executions>
+                   <execution>
+                   <id>build-specific-jar</id>
+                   <phase>package</phase>
+                   <goals>
+                       <goal>jar</goal>
+                   </goals>
+                  <configuration>                
+                      <classifier>api</classifier>
+                      <includes>                       
+                          <include>dk/kb/discover/model/**</include>
+                          <include>dk/kb/discover/util/DsDiscoverClient*</include>                                            
+                      </includes>
+                 </configuration>
+                 </execution>
+              </executions>
+            </plugin>
 
             <!-- Used only for mvn jetty:run jetty:run-war -->
             <plugin>


### PR DESCRIPTION
Build new minimum client-jar with DTO's and client class only. Use maven jar plugin. New classifier is 'api'.
Remove building old jar for all classes. Cross module dependencies use the new minimum api jar.